### PR TITLE
Fixes artisan optimization and config caching

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -217,7 +217,6 @@
             'envsetup_remotesrc',
             'depsinstall_remotesrc',
             'extracustomoverwrite_remotesrc',
-            'runtimeoptimize_remotesrc',
         ),
         'pack_remotebuildpack'=>array(
             //'show_env_remote',
@@ -234,6 +233,7 @@
             'prepare_remoterelease',
             'baseenvlink_remoterelease',
             'depsreinstall_remoterelease',
+            'runtimeoptimize_remotesrc',
         ),
         'subproc_versionsetup'=>array(
             'syncreleasetoapp_version',
@@ -985,7 +985,7 @@
 
 @task('runtimeoptimize_remotesrc',['on' => $server_labels, 'parallel' => true])
     echo "RemoteSource Runtime optimize...";
-    cd {{ $source_dir }};
+    cd {{ $release_dir }}/{{ $release }};
     if [ {{ intval($settings['runtime_optimize_component']['composer']) }} -eq 1 ]; then
         echo "Composer optimize...";
         {{ $settings['runtime_optimize_command']['composer'] }};


### PR DESCRIPTION
The actions of the `runtimeoptimize_remotesrc` task (which include the composer and artisan optimization commands) were being performed in the source directory instead of the current release directory. This was a problem because it would cause Laravel to use the source/storage directory instead of the current/storage to place cached views (causing permissions issues). 

The fix changes `runtimeoptimize_remotesrc` to be called after the release directory has been established when running the deploy command, and changes the target directory of the optimization commands to be the new release directory instead of the source directory. 
