### PR TITLE
Add hook for a custom post deploy task

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -291,7 +291,9 @@
         echo 'Calling Custom Task On Deploy...';
         cd {{ $app_dir }};
         {{-- Call your custom task on deploy eg: --}}
-        {{ customtask_on_deploy() }}
+        @if ( function_exists('customtask_on_deploy') )
+            {{ customtask_on_deploy() }}
+        @endif
         echo "Custom Task done.";
     fi
 @endtask

--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -291,7 +291,7 @@
         echo 'Calling Custom Task On Deploy...';
         cd {{ $app_dir }};
         {{-- Call your custom task on deploy eg: --}}
-        {{-- php artisan --}}
+        {{ customtask_on_deploy() }}
         echo "Custom Task done.";
     fi
 @endtask

--- a/envoy.config.example.php
+++ b/envoy.config.example.php
@@ -76,6 +76,14 @@ $exclude_addon_pattens = [
 ];
 
 /**
+ * post deployment command, should return a shell command to run
+ */
+function customtask_on_deploy() {
+    $variable = 'every server'
+    return "echo 'Custom task run on $variable post deploy.'";
+}
+
+/**
  * Misc. Settings
  */
 $settings = [


### PR DESCRIPTION
I had the need for a post deploy hook and made a modificaiton that enables the "customtask_on_deploy" which is in the blade file. 

I use this to do deploy notification to my exception handling service.

Long time since I wrote any PHP (about 7 years) so maybe there was a way to have that hook already but I could not figure it out.

